### PR TITLE
Changed deprecated method name

### DIFF
--- a/plugins/nicetime/NicetimePlugin.php
+++ b/plugins/nicetime/NicetimePlugin.php
@@ -64,7 +64,7 @@ class NicetimePlugin extends BasePlugin
 	 *
 	 * @return Twig_Extension
 	 */
-	public function hookAddTwigExtension()
+	public function addTwigExtension()
 	{
 		// require our Nicetime_Twig_Extension class definition
 		require_once craft()->path->getPluginsPath() . 'nicetime/twig_extensions/Nicetime_Twig_Extension.php';


### PR DESCRIPTION
The “hook” prefix on the Craft\NicetimePlugin::hookAddTwigExtension() method name has been deprecated. It should be renamed to addTwigExtension().
